### PR TITLE
Use 100% width

### DIFF
--- a/packages/template-retail-react-app/app/components/_app/index.jsx
+++ b/packages/template-retail-react-app/app/components/_app/index.jsx
@@ -291,7 +291,9 @@ const App = (props) => {
     }, [location])
 
     return isExpress ? (
-        <OfflineBoundary isOnline={false}>{children}</OfflineBoundary>
+        <OfflineBoundary isOnline={false}>
+            <div style={{width: '100%'}}>{children}</div>
+        </OfflineBoundary>
     ) : (
         <Box className="sf-app" {...styles.container}>
             <StorefrontPreview getToken={getTokenWhenReady}>

--- a/packages/template-retail-react-app/app/styles/adyen-overrides.css
+++ b/packages/template-retail-react-app/app/styles/adyen-overrides.css
@@ -1,4 +1,4 @@
 .adyen-checkout__applepay__button {
-    width: 415px !important;
+    width: 100% !important;
     height: 100% !important;
 }


### PR DESCRIPTION
**Overview**

Replaced hardcoded width on the ApplePay button to adjust to multiple screen + browser window sizes.